### PR TITLE
remove dependency on community.general.docker_compose

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -65,11 +65,11 @@
 
      # Start services
      - name: Start proxy service
-       community.general.docker_compose:
-         project_src: /srv/proxy
+       shell: |
+         cd /srv/proxy && docker-compose up -d
      - name: Start ddosdb service
-       community.general.docker_compose:
-         project_src: /srv/ddosdb
+       shell: |
+         cd /srv/ddosdb && docker-compose up -d
 
      # Housekeeping
      - name: Create ElasticSearch index
@@ -123,8 +123,8 @@
      
      # Start service
      - name: Start ddosgrid service
-       community.general.docker_compose:
-         project_src: /srv/ddosgrid-v2
+       shell: |
+         cd /srv/ddosgrid-v2 && docker-compose up -d
 
      - name: Print next steps
        ansible.builtin.debug:


### PR DESCRIPTION
It does not seem to be available anymore.

Keep in mind this does still not 100% work. the apt requirement for docker-compose didn't fully seem to work for me. And ofcourse https://github.com/ddosgrid/configuration-management/issues/1

Just PR'ing incase someone comes along and wants to get it setup. I ended up giving up after getting stuck with the nginx config for the oauth url parameters, but the project itself seems to get started just fine